### PR TITLE
Keep original word before lemmatization

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ More details can be found [here](https://github.com/Dankoy/korvo-to-anki-lemmati
 ```shell
 shell:>lavko
 18:04:19.608 [main] INFO  r.d.k.c.d.v.v.VocabularyDaoJdbc - Batch size: 100
-18:04:19.608 [main] INFO  r.d.k.c.d.v.v.VocabularyDaoJdbc - Batch: [VocabularyLemmaFullDTO[word=dripping, lemma=drip, title=Title[id=1, name=Orcs, filter=1], createTime=1658041927, reviewTime=0, dueTime=1658042227, reviewCount=0, prevContext=null, nextContext=null, streakCount=0], VocabularyLemmaFullDTO[word=marshlands, lemma=marshland, 
+18:04:19.608 [main] INFO  r.d.k.c.d.v.v.VocabularyDaoJdbc - Batch: [VocabularyLemmaFullDTO[word=dripping, lemma=drip, title=Title[id=1, name=Orcs, filter=1], createTime=1658041927, reviewTime=0, dueTime=1658042227, reviewCount=0, prevContext=null, nextContext=(dripping), streakCount=0], VocabularyLemmaFullDTO[word=marshlands, lemma=marshland, 
 ...
 ```
 

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ If you want to keep original words then use `lavko` command.
 
 This command will keep original word and put it in nextContext in db. 
  
-More details can be found [here](https://github.com/Dankoy/korvo-to-anki-lemmatizer/pull/30)
+More details can be found [here](https://github.com/Dankoy/korvo-to-anki-lemmatizer/issues/29)
 
 ```shell
 shell:>lavko

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Functionality:
 1) Check duplicated words and delete them in db
 2) Check for words that already has lemmas in db and delete them from db.
 3) Get lemmas from words and update them in db
+4) Possible to keep original words after lemmatization in db. More [here](https://github.com/Dankoy/korvo-to-anki-lemmatizer/issues/29)
 
 To correctly use this project, it's necessary to keep in mind that backups are absolutely necessary,
 and automatic operations for duplicates removal should be done on your own risk. You can check
@@ -150,10 +151,29 @@ shell:>add
 
 After deleting got to step 5
 
-## 5. Lemmatize your db
+## 5. Lemmatize your db and keep or not keep original words 
+
+### Don't keep original words
+
+If you don't want to keep original words then use `lav` command
 
 ```shell
 shell:>lav
+18:04:19.608 [main] INFO  r.d.k.c.d.v.v.VocabularyDaoJdbc - Batch size: 100
+18:04:19.608 [main] INFO  r.d.k.c.d.v.v.VocabularyDaoJdbc - Batch: [VocabularyLemmaFullDTO[word=dripping, lemma=drip, title=Title[id=1, name=Orcs, filter=1], createTime=1658041927, reviewTime=0, dueTime=1658042227, reviewCount=0, prevContext=null, nextContext=null, streakCount=0], VocabularyLemmaFullDTO[word=marshlands, lemma=marshland, 
+...
+```
+
+### Keep original words
+
+If you want to keep original words then use `lavko` command. 
+
+This command will keep original word and put it in nextContext in db. 
+ 
+More details can be found [here](https://github.com/Dankoy/korvo-to-anki-lemmatizer/pull/30)
+
+```shell
+shell:>lavko
 18:04:19.608 [main] INFO  r.d.k.c.d.v.v.VocabularyDaoJdbc - Batch size: 100
 18:04:19.608 [main] INFO  r.d.k.c.d.v.v.VocabularyDaoJdbc - Batch: [VocabularyLemmaFullDTO[word=dripping, lemma=drip, title=Title[id=1, name=Orcs, filter=1], createTime=1658041927, reviewTime=0, dueTime=1658042227, reviewCount=0, prevContext=null, nextContext=null, streakCount=0], VocabularyLemmaFullDTO[word=marshlands, lemma=marshland, 
 ...

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
     <lombok-mapstruct-binding.version>0.2.0</lombok-mapstruct-binding.version>
     <spotless.version>3.1.0</spotless.version>
     <spotless-plugin.version>2.44.3</spotless-plugin.version>
-    <google-java-format>1.19.2</google-java-format>
+    <google-java-format>1.26.0</google-java-format>
   </properties>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
   <groupId>ru.dankoy</groupId>
   <artifactId>korvo-to-anki-lemmatizer</artifactId>
-  <version>0.1.7</version>
+  <version>0.2.0</version>
   <name>korvo-to-anki-lemmatizer</name>
   <description>korvo-to-anki-lemmatizer</description>
   <packaging>jar</packaging>
@@ -142,17 +142,19 @@
             <!-- no need to specify files, inferred automatically, but you can if you want -->
 
             <cleanthat>
-              <version>2.8</version>                          <!-- optional version of Cleanthat -->
+              <version>2.22</version>                          <!-- optional version of Cleanthat -->
               <sourceJdk>${maven.compiler.source}</sourceJdk> <!-- optional. Default to ${maven.compiler.source} else '1.7' -->
               <mutators>
                 <mutator>SafeAndConsensual</mutator>          <!-- optional. Default to 'SafeAndConsensual' to include all mutators -->
+                <mutator>SonarMutators</mutator>
+                <mutator>SpotBugsMutators</mutator>
               </mutators>
-              <mutators>            <!-- List of mutators: https://github.com/solven-eu/cleanthat/blob/master/MUTATORS.generated.MD -->
-                <mutator>LiteralsFirstInComparisons</mutator> <!-- You may alternatively list the requested mutators -->
-              </mutators>
-              <excludedMutators>
-                <excludedMutator>OptionalNotEmpty</excludedMutator> <!-- You can discard specific rules -->
-              </excludedMutators>
+              <!-- <mutators>            List of mutators: https://github.com/solven-eu/cleanthat/blob/master/MUTATORS.generated.MD -->
+                <!-- <mutator>LiteralsFirstInComparisons</mutator> You may alternatively list the requested mutators -->
+              <!-- </mutators> -->
+               <excludedMutators>
+                <excludedMutator>AvoidInlineConditionals</excludedMutator> <!-- You can discard specific rules -->
+              </excludedMutators> 
               <includeDraft>false</includeDraft>              <!-- optional. Default to false, not to include draft mutators from Composite mutators -->
             </cleanthat>
 

--- a/src/main/java/ru/dankoy/korvotoanki/core/command/LemmatizerCommand.java
+++ b/src/main/java/ru/dankoy/korvotoanki/core/command/LemmatizerCommand.java
@@ -183,6 +183,9 @@ public class LemmatizerCommand {
   private List<VocabularyLemmaFullDTO> keepOriginalWordWithLemma(
       List<VocabularyLemmaFullDTO> dtoList) {
     return dtoList.stream()
+        .filter(v -> v.word().split(" ").length == 1)
+        .filter(v -> !v.word().contains("-"))
+        .filter(dto -> !dto.word().equals(dto.lemma())) // filter if word is equals lemma
         .map(
             vcl -> {
               var originalWithNextContext = String.format("(%s)%s", vcl.word(), vcl.nextContext());

--- a/src/main/java/ru/dankoy/korvotoanki/core/command/LemmatizerCommand.java
+++ b/src/main/java/ru/dankoy/korvotoanki/core/command/LemmatizerCommand.java
@@ -188,7 +188,7 @@ public class LemmatizerCommand {
         .filter(dto -> !dto.word().equals(dto.lemma())) // filter if word is equals lemma
         .map(
             vcl -> {
-              var originalWithNextContext = String.format("(%s)%s", vcl.word(), vcl.nextContext());
+              var originalWithNextContext = vcl.nextContext() == null ? String.format("(%s)", vcl.word()) : String.format("(%s)%s", vcl.word(), vcl.nextContext());
               return new VocabularyLemmaFullDTO(
                   vcl.word(),
                   vcl.lemma(),

--- a/src/main/java/ru/dankoy/korvotoanki/core/command/LemmatizerCommand.java
+++ b/src/main/java/ru/dankoy/korvotoanki/core/command/LemmatizerCommand.java
@@ -188,7 +188,10 @@ public class LemmatizerCommand {
         .filter(dto -> !dto.word().equals(dto.lemma())) // filter if word is equals lemma
         .map(
             vcl -> {
-              var originalWithNextContext = vcl.nextContext() == null ? String.format("(%s)", vcl.word()) : String.format("(%s)%s", vcl.word(), vcl.nextContext());
+              var originalWithNextContext =
+                  vcl.nextContext() == null
+                      ? String.format("(%s)", vcl.word())
+                      : String.format("(%s)%s", vcl.word(), vcl.nextContext());
               return new VocabularyLemmaFullDTO(
                   vcl.word(),
                   vcl.lemma(),

--- a/src/main/java/ru/dankoy/korvotoanki/core/dao/vocabularybuilder/vocabulary/VocabularyDaoJdbc.java
+++ b/src/main/java/ru/dankoy/korvotoanki/core/dao/vocabularybuilder/vocabulary/VocabularyDaoJdbc.java
@@ -105,20 +105,21 @@ public class VocabularyDaoJdbc implements VocabularyDao {
 
         rowsUpdated =
             vocabularyJdbcOperations.batchUpdate(
-              """
-                  update vocabulary set 
-                  title_id = :title.id, 
-                  create_time = :createTime, 
-                  review_time = :reviewTime, 
-                  due_time = :dueTime, 
-                  review_count = :reviewCount, 
-                  prev_context = :prevContext, 
-                  next_context = :nextContext, 
-                  streak_count = :streakCount, 
+                """
+                  update vocabulary set
+                  title_id = :title.id,
+                  create_time = :createTime,
+                  review_time = :reviewTime,
+                  due_time = :dueTime,
+                  review_count = :reviewCount,
+                  prev_context = :prevContext,
+                  next_context = :nextContext,
+                  streak_count = :streakCount,
                   word = :lemma
                   where word = :word
-                  """, 
-                batchParams, keyHolder);
+                  """,
+                batchParams,
+                keyHolder);
 
       } catch (Exception ex) {
         throw new VocabularyDaoException(ex);

--- a/src/main/java/ru/dankoy/korvotoanki/core/dao/vocabularybuilder/vocabulary/VocabularyDaoJdbc.java
+++ b/src/main/java/ru/dankoy/korvotoanki/core/dao/vocabularybuilder/vocabulary/VocabularyDaoJdbc.java
@@ -106,18 +106,18 @@ public class VocabularyDaoJdbc implements VocabularyDao {
         rowsUpdated =
             vocabularyJdbcOperations.batchUpdate(
                 """
-                  update vocabulary set
-                  title_id = :title.id,
-                  create_time = :createTime,
-                  review_time = :reviewTime,
-                  due_time = :dueTime,
-                  review_count = :reviewCount,
-                  prev_context = :prevContext,
-                  next_context = :nextContext,
-                  streak_count = :streakCount,
-                  word = :lemma
-                  where word = :word
-                  """,
+                update vocabulary set
+                title_id = :title.id,
+                create_time = :createTime,
+                review_time = :reviewTime,
+                due_time = :dueTime,
+                review_count = :reviewCount,
+                prev_context = :prevContext,
+                next_context = :nextContext,
+                streak_count = :streakCount,
+                word = :lemma
+                where word = :word
+                """,
                 batchParams,
                 keyHolder);
 

--- a/src/main/java/ru/dankoy/korvotoanki/core/dao/vocabularybuilder/vocabulary/VocabularyDaoJdbc.java
+++ b/src/main/java/ru/dankoy/korvotoanki/core/dao/vocabularybuilder/vocabulary/VocabularyDaoJdbc.java
@@ -105,7 +105,20 @@ public class VocabularyDaoJdbc implements VocabularyDao {
 
         rowsUpdated =
             vocabularyJdbcOperations.batchUpdate(
-                "update vocabulary set word = :lemma where word =:word", batchParams, keyHolder);
+              """
+                  update vocabulary set 
+                  title_id = :title.id, 
+                  create_time = :createTime, 
+                  review_time = :reviewTime, 
+                  due_time = :dueTime, 
+                  review_count = :reviewCount, 
+                  prev_context = :prevContext, 
+                  next_context = :nextContext, 
+                  streak_count = :streakCount, 
+                  word = :lemma
+                  where word = :word
+                  """, 
+                batchParams, keyHolder);
 
       } catch (Exception ex) {
         throw new VocabularyDaoException(ex);

--- a/src/test/java/ru/dankoy/korvotoanki/core/dao/vocabularybuilder/vocabulary/VocabularyDaoJdbcTest.java
+++ b/src/test/java/ru/dankoy/korvotoanki/core/dao/vocabularybuilder/vocabulary/VocabularyDaoJdbcTest.java
@@ -104,16 +104,17 @@ class VocabularyDaoJdbcTest {
             new Vocabulary(
                 "contemplating",
                 title,
-                1695239837,
-                1695239837,
-                1695240137,
+                1_695_239_837,
+                1_695_239_837,
+                1_695_240_137,
                 0,
                 "combined forces.” He hoped to the gods it didn’t come to that.\n"
                     + "She fell silent, ",
                 " a gratifying slaughter. Maybe even the final battle that would confirm her"
                     + " mastery. Most of all",
                 0),
-            new Vocabulary("word", title, 1695239837, 1695239837, 1695240137, 0, null, null, 0))
+            new Vocabulary(
+                "word", title, 1_695_239_837, 1_695_239_837, 1_695_240_137, 0, null, null, 0))
         .toList();
   }
 }

--- a/src/test/java/ru/dankoy/korvotoanki/core/service/vocabulary/VocabularyServiceJdbcTest.java
+++ b/src/test/java/ru/dankoy/korvotoanki/core/service/vocabulary/VocabularyServiceJdbcTest.java
@@ -80,16 +80,17 @@ class VocabularyServiceJdbcTest {
             new Vocabulary(
                 "contemplating",
                 title,
-                1695239837,
-                1695239837,
-                1695240137,
+                1_695_239_837,
+                1_695_239_837,
+                1_695_240_137,
                 0,
                 "combined forces.” He hoped to the gods it didn’t come to that.\n"
                     + "She fell silent, ",
                 " a gratifying slaughter. Maybe even the final battle that would confirm her"
                     + " mastery. Most of all",
                 0),
-            new Vocabulary("word", title, 1695239837, 1695239837, 1695240137, 0, null, null, 0))
+            new Vocabulary(
+                "word", title, 1_695_239_837, 1_695_239_837, 1_695_240_137, 0, null, null, 0))
         .toList();
   }
 }


### PR DESCRIPTION
# Description

Added shell command to keep original words in nextContext in database.

Updated update sql to actually update everything.

Also fixed some minor bugs.

Fixes #29 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Try lemmatize words. Check if original word is kept in database.
- [x] Try lemmatize vocabulary consists from more than one word. These vocabularies should not appear as kept word.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

