### PR TITLE
Lemmatize all words

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ was' is 'be' and lemma for word 'maintained' is 'maintain'.
 
 So this app checks for such words and rewrites it in lemmas.
 
-> [!Attention]
+> [!ATTENTION]
 > 
 > Lemmatization works only for strings containing
 > 1) one word without hyphen (held)

--- a/README.md
+++ b/README.md
@@ -43,7 +43,12 @@ was' is 'be' and lemma for word 'maintained' is 'maintain'.
 
 So this app checks for such words and rewrites it in lemmas.
 
-Lemmatization works only for strings containing multiple word without hyphen.
+> [!Attention]
+> 
+> Lemmatization works only for strings containing
+> 1) one word without hyphen (held)
+> 2) multiple words without hyphen (gave back)
+
 
 # Usage
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ was' is 'be' and lemma for word 'maintained' is 'maintain'.
 
 So this app checks for such words and rewrites it in lemmas.
 
-Lemmatization works only for strings containing one word or hyphen.
+Lemmatization works only for strings containing multiple word without hyphen.
 
 # Usage
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ was' is 'be' and lemma for word 'maintained' is 'maintain'.
 
 So this app checks for such words and rewrites it in lemmas.
 
-> [!ATTENTION]
+> [!NOTE]
 > 
 > Lemmatization works only for strings containing
 > 1) one word without hyphen (held)

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
   <groupId>ru.dankoy</groupId>
   <artifactId>korvo-to-anki-lemmatizer</artifactId>
-  <version>0.3.0</version>
+  <version>0.4.0</version>
   <name>korvo-to-anki-lemmatizer</name>
   <description>korvo-to-anki-lemmatizer</description>
   <packaging>jar</packaging>

--- a/src/main/java/ru/dankoy/korvotoanki/core/command/LemmatizerCommand.java
+++ b/src/main/java/ru/dankoy/korvotoanki/core/command/LemmatizerCommand.java
@@ -7,6 +7,7 @@ import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.shell.core.command.annotation.Command;
+import org.springframework.shell.core.command.annotation.Option;
 import org.springframework.shell.core.command.availability.Availability;
 import org.springframework.shell.core.command.availability.AvailabilityProvider;
 import org.springframework.stereotype.Component;
@@ -160,6 +161,35 @@ public class LemmatizerCommand {
     return objectMapperService.convertToStringPrettyPrint(dtos);
   }
 
+  @Command(
+      group = "lemmatize",
+      name = {"lemmatize-word"},
+      alias = "lw",
+      description =
+          """
+          Lemmatize a single word.
+          Should be used only if you want to check how lemmatizer works on a single word.
+          """)
+  public String lemmatizeWord(
+      @Option(
+              required = true,
+              description = "The word to lemmatize",
+              shortName = 'w',
+              longName = "word")
+          String word) {
+
+    Vocabulary vocab = new Vocabulary(word, null, 0, 0, 0, 0, null, null, 0);
+    List<Vocabulary> vocabulary = List.of(vocab);
+
+    List<VocabularyLemmaFullDTO> res = lemmatizerService.lemmatize(vocabulary);
+
+    var keepOriginalDto = keepOriginalWordWithLemma(res);
+
+    var dtos = keepOriginalDto.stream().map(vocabularyMapper::fromFullDto).toList();
+
+    return objectMapperService.convertToStringPrettyPrint(dtos);
+  }
+
   @Bean
   public AvailabilityProvider lemmatizeAvailability() {
     return () ->
@@ -187,9 +217,7 @@ public class LemmatizerCommand {
   private List<VocabularyLemmaFullDTO> keepOriginalWordWithLemma(
       List<VocabularyLemmaFullDTO> dtoList) {
     return dtoList.stream()
-        .filter(v -> v.word().split(" ").length == 1)
         .filter(v -> !v.word().contains("-"))
-        .filter(dto -> !dto.word().equals(dto.lemma())) // filter if word is equals lemma
         .map(
             vcl -> {
               var originalWithNextContext =

--- a/src/main/java/ru/dankoy/korvotoanki/core/service/lemmatizer/LemmatizerServiceVirtualThreads.java
+++ b/src/main/java/ru/dankoy/korvotoanki/core/service/lemmatizer/LemmatizerServiceVirtualThreads.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -36,7 +37,6 @@ public class LemmatizerServiceVirtualThreads implements LemmatizerService {
     try (ExecutorService executorService = Executors.newVirtualThreadPerTaskExecutor()) {
       List<CompletableFuture<VocabularyLemmaFullDTO>> cfs =
           dtos.stream()
-              .filter(v -> v.word().split(" ").length == 1)
               .filter(v -> !v.word().contains("-"))
               .map(
                   dto -> {
@@ -53,11 +53,7 @@ public class LemmatizerServiceVirtualThreads implements LemmatizerService {
           CompletableFuture.allOf(cfs.toArray(new CompletableFuture[cfs.size()]))
               .thenApply(
                   // map cfs results into list
-                  future -> cfs.stream().map(CompletableFuture::join).flatMap(Stream::of).toList())
-              .thenApply(
-                  // filter words
-                  resultList ->
-                      resultList.stream().filter(v -> !v.word().equals(v.lemma())).toList());
+                  future -> cfs.stream().map(CompletableFuture::join).flatMap(Stream::of).toList());
 
       return allOf.join();
     }
@@ -67,6 +63,11 @@ public class LemmatizerServiceVirtualThreads implements LemmatizerService {
 
     // lemmatize vocabs containing only one word
     var coreDoc = stanfordCoreNLP.processToCoreDocument(vocabulary.word());
-    return vocabularyMapper.updateLemmaDto(coreDoc.tokens().get(0).lemma(), vocabulary);
+
+    // convert list of CoreDocuments to string of lemmatized words
+    var lemmaWord =
+        coreDoc.tokens().stream().map(token -> token.lemma()).collect(Collectors.joining(" "));
+
+    return vocabularyMapper.updateLemmaDto(lemmaWord, vocabulary);
   }
 }

--- a/src/test/java/ru/dankoy/korvotoanki/core/service/lemmatizer/LemmatizerServiceVirtualThreadsTest.java
+++ b/src/test/java/ru/dankoy/korvotoanki/core/service/lemmatizer/LemmatizerServiceVirtualThreadsTest.java
@@ -1,0 +1,154 @@
+package ru.dankoy.korvotoanki.core.service.lemmatizer;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import edu.stanford.nlp.ling.CoreLabel;
+import edu.stanford.nlp.pipeline.CoreDocument;
+import edu.stanford.nlp.pipeline.StanfordCoreNLP;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import ru.dankoy.korvotoanki.core.domain.Vocabulary;
+import ru.dankoy.korvotoanki.core.dto.VocabularyLemmaFullDTO;
+import ru.dankoy.korvotoanki.core.mapper.VocabularyMapper;
+
+@DisplayName("Test LemmatizerServiceVirtualThreads ")
+@ExtendWith(MockitoExtension.class)
+public class LemmatizerServiceVirtualThreadsTest {
+
+  @Mock private StanfordCoreNLP stanfordCoreNLP;
+
+  @Mock private VocabularyMapper vocabularyMapper;
+
+  @InjectMocks private LemmatizerServiceVirtualThreads lemmatizerService;
+
+  @Test
+  public void testLemmatizeWithSingleWordWithWhitespaceVocabulary_expectsCorrectResult() {
+
+    // Arrange
+    Vocabulary vocabulary = new Vocabulary("example word", null, 0, 0, 0, 0, null, null, 0);
+    VocabularyLemmaFullDTO expectedDto =
+        new VocabularyLemmaFullDTO("example word", "example word", null, 0, 0, 0, 0, null, null, 0);
+
+    var coreDocMock = mock(CoreDocument.class);
+    var tokenMock1 = mock(CoreLabel.class);
+    var tokenMock2 = mock(CoreLabel.class);
+
+    when(tokenMock1.lemma()).thenReturn("example");
+    when(tokenMock2.lemma()).thenReturn("word");
+
+    when(coreDocMock.tokens()).thenReturn(List.of(tokenMock1, tokenMock2));
+
+    when(vocabularyMapper.addLemmaDto(vocabulary)).thenReturn(expectedDto);
+    when(vocabularyMapper.updateLemmaDto(Mockito.anyString(), Mockito.eq(expectedDto)))
+        .thenReturn(expectedDto);
+    when(stanfordCoreNLP.processToCoreDocument("example word")).thenReturn(coreDocMock);
+
+    // Act
+    List<VocabularyLemmaFullDTO> result = lemmatizerService.lemmatize(List.of(vocabulary));
+
+    // Assert
+    assertEquals(1, result.size());
+    assertEquals(expectedDto, result.get(0));
+  }
+
+  @Test
+  public void testLemmatizeWithSingleWordWithoutWhitespaceVocabulary_expectsCorrectResult() {
+
+    // Arrange
+    Vocabulary vocabulary = new Vocabulary("example", null, 0, 0, 0, 0, null, null, 0);
+    VocabularyLemmaFullDTO expectedDto =
+        new VocabularyLemmaFullDTO("example", "example", null, 0, 0, 0, 0, null, null, 0);
+
+    var coreDocMock = mock(CoreDocument.class);
+    var tokenMock1 = mock(CoreLabel.class);
+
+    when(tokenMock1.lemma()).thenReturn("example");
+
+    when(coreDocMock.tokens()).thenReturn(List.of(tokenMock1));
+
+    when(vocabularyMapper.addLemmaDto(vocabulary)).thenReturn(expectedDto);
+    when(vocabularyMapper.updateLemmaDto(Mockito.anyString(), Mockito.eq(expectedDto)))
+        .thenReturn(expectedDto);
+    when(stanfordCoreNLP.processToCoreDocument("example")).thenReturn(coreDocMock);
+
+    // Act
+    List<VocabularyLemmaFullDTO> result = lemmatizerService.lemmatize(List.of(vocabulary));
+
+    // Assert
+    assertEquals(1, result.size());
+    assertEquals(expectedDto, result.get(0));
+  }
+
+  @Test
+  public void testLemmatizeWithSingleWordVocabulary_expectsFilteringWordWithDash() {
+
+    // Arrange
+    Vocabulary vocabulary = new Vocabulary("example-word", null, 0, 0, 0, 0, null, null, 0);
+    VocabularyLemmaFullDTO expectedDto =
+        new VocabularyLemmaFullDTO("example-word", "example-word", null, 0, 0, 0, 0, null, null, 0);
+
+    when(vocabularyMapper.addLemmaDto(vocabulary)).thenReturn(expectedDto);
+
+    // Act
+    List<VocabularyLemmaFullDTO> result = lemmatizerService.lemmatize(List.of(vocabulary));
+
+    // Assert
+    assertEquals(0, result.size());
+  }
+
+  @Test
+  public void testLemmatizeWithMultipleWordVocabulary_expectsFilteringWordWithDash() {
+
+    // Arrange
+    Vocabulary vocabulary1 = new Vocabulary("example word", null, 0, 0, 0, 0, null, null, 0);
+    Vocabulary vocabulary2 = new Vocabulary("example-word", null, 0, 0, 0, 0, null, null, 0);
+
+    VocabularyLemmaFullDTO expectedDto1 =
+        new VocabularyLemmaFullDTO("example word", "example word", null, 0, 0, 0, 0, null, null, 0);
+    VocabularyLemmaFullDTO expectedDto2 =
+        new VocabularyLemmaFullDTO("example-word", "example-word", null, 0, 0, 0, 0, null, null, 0);
+
+    var coreDocMock = mock(CoreDocument.class);
+    var tokenMock1 = mock(CoreLabel.class);
+    var tokenMock2 = mock(CoreLabel.class);
+
+    when(tokenMock1.lemma()).thenReturn("example");
+    when(tokenMock2.lemma()).thenReturn("word");
+
+    when(coreDocMock.tokens()).thenReturn(List.of(tokenMock1, tokenMock2));
+
+    when(vocabularyMapper.addLemmaDto(vocabulary1)).thenReturn(expectedDto1);
+    when(vocabularyMapper.addLemmaDto(vocabulary2)).thenReturn(expectedDto2);
+    when(vocabularyMapper.updateLemmaDto(Mockito.anyString(), Mockito.eq(expectedDto1)))
+        .thenReturn(expectedDto1);
+    when(stanfordCoreNLP.processToCoreDocument("example word")).thenReturn(coreDocMock);
+
+    // Act
+    List<VocabularyLemmaFullDTO> result =
+        lemmatizerService.lemmatize(List.of(vocabulary1, vocabulary2));
+
+    // Assert
+    assertEquals(1, result.size());
+    assertEquals(expectedDto1, result.get(0));
+  }
+
+  @Test
+  public void testLemmatizeWithException() {
+    // Arrange
+    Vocabulary vocabulary = new Vocabulary("example-word", null, 0, 0, 0, 0, null, null, 0);
+    when(vocabularyMapper.addLemmaDto(vocabulary)).thenReturn(null);
+
+    // Act
+    assertThatThrownBy(() -> lemmatizerService.lemmatize(List.of(vocabulary)))
+        .isInstanceOf(NullPointerException.class);
+  }
+}


### PR DESCRIPTION
# Description

Added possibility to lemmatize words with whitespaces like 'gave back', etc.

Also added command to lemmatize word from arguments to command.

Added tests.

Updated release version to 0.4.0

Fixes #81

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Lemmatize words with whitespace. It should work correctly.
- [x] Lemmatize words with hyphen. These words should be ignored.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

